### PR TITLE
Fix: Configure workflow for LearnQuickTyping subdirectory structure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,15 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+      SuppressNETCoreSdkPreviewMessage: true
+      MSBuildWarningsAsMessages: NETSDK1202
+    defaults:
+      run:
+        working-directory: LearnQuickTyping
+    
     steps:
       - name: Haal de repository op
         uses: actions/checkout@v4
@@ -20,20 +29,21 @@ jobs:
       - name: Installeer .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '8.0.404'
+          dotnet-quality: 'ga'
  
       - name: Installeer MAUI workloads
         run: dotnet workload install maui-android
  
-      - name: Herstel afhankelijkheden
-        run: dotnet restore
+      - name: Herstel test project afhankelijkheden
+        run: dotnet restore LearnQuickTyping.TestCore/LearnQuickTyping.TestCore.csproj
  
-      - name: Bouw de applicatie
-        run: dotnet build --configuration Release --no-restore
+      - name: Bouw test project
+        run: dotnet build LearnQuickTyping.TestCore/LearnQuickTyping.TestCore.csproj --configuration Release --no-restore
  
       - name: Voer geautomatiseerde tests uit
         run: |
-          dotnet test LearnQuickTyping/LearnQuickTyping.TestCore/LearnQuickTyping.TestCore.csproj \
+          dotnet test LearnQuickTyping.TestCore/LearnQuickTyping.TestCore.csproj \
             --configuration Release \
             --no-restore --no-build \
             --logger "trx;LogFileName=TestResults.trx" \
@@ -81,6 +91,6 @@ jobs:
         with:
           name: test-resultaten
           path: |
-            TestResults/TestResults.trx
-            TestResults/test-log.txt
+            LearnQuickTyping/TestResults/TestResults.trx
+            LearnQuickTyping/TestResults/test-log.txt
         if: always()


### PR DESCRIPTION
Fixed workflow errors caused by project files being in a subdirectory:
- Added working-directory: LearnQuickTyping to run all commands in correct location
- Pinned .NET SDK to 8.0.404 to match MAUI app target framework
- Added environment variables to suppress SDK warnings (NETSDK1202)
- Changed to build only test project instead of entire solution
- Updated artifact upload paths to include LearnQuickTyping/ prefix

Resolved errors:
- MSB1003: "Current working directory does not contain a project or solution file"
- TestResults/test-log.txt: "No such file or directory"