### PR TITLE
UC1: US1 + Performance improvements

### DIFF
--- a/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
@@ -17,6 +17,7 @@ public partial class TextExerciseViewModel : BaseViewModel
 
     private DateTime _startTime;
     private bool _isTiming;
+    private bool _isTransitioning; // Prevent updates during sentence transition
 
     private List<string> _sentences = new();
     private int _currentSentenceIndex;
@@ -26,13 +27,13 @@ public partial class TextExerciseViewModel : BaseViewModel
     private string _allTypedText = string.Empty;
 
     [ObservableProperty]
-    private string _targetText;
+    private string _targetText = string.Empty;
 
     [ObservableProperty]
-    private string _inputText;
+    private string _inputText = string.Empty;
 
     [ObservableProperty]
-    private string _typedText;
+    private string _typedText = string.Empty;
 
     [ObservableProperty]
     private string _timeDisplay = "Current time: 0,00s";
@@ -50,7 +51,7 @@ public partial class TextExerciseViewModel : BaseViewModel
     private string _progressDisplay = "Sentence: 0/0";
 
     [ObservableProperty]
-    private string _resultMessage;
+    private string _resultMessage = string.Empty;
 
     [ObservableProperty]
     private Color _resultColor = Colors.Black;
@@ -62,10 +63,10 @@ public partial class TextExerciseViewModel : BaseViewModel
     private bool _isNotTurnOverlayVisible = true;
 
     [ObservableProperty]
-    private string _completeMessage;
+    private string _completeMessage = string.Empty;
 
-    public event Action<List<LetterStatus>> RequestLetterUpdate;
-    public event Action<string, string, string> OnLineChanged;
+    public event Action<List<LetterStatus>>? RequestLetterUpdate;
+    public event Action<string, string, string>? OnLineChanged;
 
     public TextExerciseViewModel(
         ITextRepository textRepository,
@@ -76,17 +77,21 @@ public partial class TextExerciseViewModel : BaseViewModel
         _statsService = statsService;
         _typeControl = typeControl;
 
-        _timer = Application.Current.Dispatcher.CreateTimer();
-        _timer.Interval = TimeSpan.FromMilliseconds(50);
+        _timer = Application.Current!.Dispatcher.CreateTimer();
+        _timer.Interval = TimeSpan.FromMilliseconds(100); // Reduced frequency: 100ms instead of 50ms
         _timer.Tick += OnTimerTick;
     }
 
     [RelayCommand]
     public void InitializeExercise()
     {
+        _isTransitioning = true;
+
         StopTimer();
         TimeDisplay = "Current time: 0,00s";
         WpmDisplay = "Current Words Per Minute: 0";
+        MistakeCountDisplay = "Mistakes: 0";
+        AccuracyDisplay = "Accuracy: 100%";
         InputText = string.Empty;
         TypedText = string.Empty;
         ResultMessage = string.Empty;
@@ -99,6 +104,8 @@ public partial class TextExerciseViewModel : BaseViewModel
         _statsService.ResetMistakes();
 
         LoadNewText();
+
+        _isTransitioning = false;
     }
 
     private void LoadNewText()
@@ -137,15 +144,13 @@ public partial class TextExerciseViewModel : BaseViewModel
             _typeControl.TargetText = TargetText;
             _typeControl.TypedText = string.Empty;
 
-            InputText = string.Empty;
-            TypedText = string.Empty;
-
             string prev = _currentSentenceIndex > 0 ? _sentences[_currentSentenceIndex - 1] : "";
             string next = _currentSentenceIndex + 1 < _sentences.Count ? _sentences[_currentSentenceIndex + 1] : "";
 
-            OnLineChanged?.Invoke(prev, TargetText, next);
             ProgressDisplay = $"Sentence: {_currentSentenceIndex + 1}/{_sentences.Count}";
 
+            // Notify view to update display - do this before clearing input
+            OnLineChanged?.Invoke(prev, TargetText, next);
             RequestLetterUpdate?.Invoke(_typeControl.GetLetterStatuses());
         }
         else
@@ -156,20 +161,23 @@ public partial class TextExerciseViewModel : BaseViewModel
 
     partial void OnTypedTextChanged(string value)
     {
-        if (string.IsNullOrEmpty(TargetText)) return;
+        // Skip processing during transitions to prevent cascading updates
+        if (_isTransitioning || string.IsNullOrEmpty(TargetText))
+            return;
 
-        if (!_isTiming && !string.IsNullOrEmpty(value))
+        string safeValue = value ?? string.Empty;
+
+        if (!_isTiming && !string.IsNullOrEmpty(safeValue))
         {
             StartTimer();
         }
-
-        string safeValue = value ?? string.Empty;
 
         _typeControl.CheckTyping(safeValue);
         _statsService.TrackMistakes(safeValue, TargetText);
 
         RequestLetterUpdate?.Invoke(_typeControl.GetLetterStatuses());
 
+        // Check for sentence completion
         if (safeValue.Length >= TargetText.Length)
         {
             CompleteSentence();
@@ -178,6 +186,8 @@ public partial class TextExerciseViewModel : BaseViewModel
 
     private void CompleteSentence()
     {
+        _isTransitioning = true;
+
         _accumulatedMistakes += _statsService.GetMistakeCount();
         _accumulatedWords += CountWords(TargetText);
         _allTypedText += TypedText + " ";
@@ -185,7 +195,17 @@ public partial class TextExerciseViewModel : BaseViewModel
         _statsService.ResetMistakes();
 
         _currentSentenceIndex++;
-        LoadCurrentSentence();
+
+        // Clear input fields before loading new sentence
+        InputText = string.Empty;
+        TypedText = string.Empty;
+
+        // Small delay to let UI settle before loading next sentence
+        Application.Current?.Dispatcher.Dispatch(() =>
+        {
+            LoadCurrentSentence();
+            _isTransitioning = false;
+        });
     }
 
     private int CountWords(string text)
@@ -206,32 +226,32 @@ public partial class TextExerciseViewModel : BaseViewModel
         _timer.Stop();
     }
 
-    private void OnTimerTick(object sender, EventArgs e)
+    private void OnTimerTick(object? sender, EventArgs e)
     {
-        if (_isTiming)
+        if (!_isTiming || _isTransitioning)
+            return;
+
+        var elapsed = DateTime.Now - _startTime;
+        TimeDisplay = $"Current time: {elapsed.TotalSeconds:F2}s";
+
+        int currentWords = CountWords(TypedText);
+        int totalWords = _accumulatedWords + currentWords;
+        double wpm = elapsed.TotalMinutes > 0 ? totalWords / elapsed.TotalMinutes : 0;
+
+        WpmDisplay = $"Current words per minute: {wpm:F0}"; // Reduced decimal places
+
+        int currentMistakes = _statsService.GetMistakeCount();
+        int totalMistakes = _accumulatedMistakes + currentMistakes;
+        MistakeCountDisplay = $"Mistakes: {totalMistakes}";
+
+        int totalChars = _allTypedText.Length + (TypedText?.Length ?? 0);
+        int accuracy = 100;
+        if (totalChars > 0)
         {
-            var elapsed = DateTime.Now - _startTime;
-            TimeDisplay = $"Current time: {elapsed.TotalSeconds:F2}s";
-
-            int currentWords = CountWords(TypedText);
-            int totalWords = _accumulatedWords + currentWords;
-            double wpm = elapsed.TotalMinutes > 0 ? totalWords / elapsed.TotalMinutes : 0;
-
-            WpmDisplay = $"Current words per minute: {wpm:F2}";
-
-            int currentMistakes = _statsService.GetMistakeCount();
-            int totalMistakes = _accumulatedMistakes + currentMistakes;
-            MistakeCountDisplay = $"Mistakes: {totalMistakes}";
-
-            int totalChars = _allTypedText.Length + (TypedText?.Length ?? 0);
-            int accuracy = 100;
-            if (totalChars > 0)
-            {
-                double errorRate = (double)totalMistakes / totalChars;
-                accuracy = Math.Max(0, (int)((1 - errorRate) * 100));
-            }
-            AccuracyDisplay = $"Accuracy: {accuracy}%";
+            double errorRate = (double)totalMistakes / totalChars;
+            accuracy = Math.Max(0, (int)((1 - errorRate) * 100));
         }
+        AccuracyDisplay = $"Accuracy: {accuracy}%";
     }
 
     [RelayCommand]
@@ -257,7 +277,6 @@ public partial class TextExerciseViewModel : BaseViewModel
 
         CompleteMessage = $"Exercise Complete!\n\nTime: {elapsed.TotalSeconds:F2}s\nWPM: {wpm:F2}\nMistakes: {_accumulatedMistakes}\nAccuracy: {accuracy}%\n\nPress Enter to continue";
 
-        // Always show result overlay
         IsTurnOverlayVisible = true;
         IsNotTurnOverlayVisible = false;
     }
@@ -265,7 +284,6 @@ public partial class TextExerciseViewModel : BaseViewModel
     [RelayCommand]
     private void StartExercise()
     {
-        // Hide overlay
         IsTurnOverlayVisible = false;
         IsNotTurnOverlayVisible = true;
         InitializeExercise();

--- a/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
@@ -4,6 +4,7 @@ using LearnQuickTyping.Core.Interfaces;
 using LearnQuickTyping.Core.Interfaces.Repositories;
 using LearnQuickTyping.Core.Interfaces.Services;
 using LearnQuickTyping.Core.Models;
+using System.Text.RegularExpressions;
 
 namespace LearnQuickTyping.App.ViewModels;
 
@@ -16,6 +17,13 @@ public partial class TextExerciseViewModel : BaseViewModel
 
     private DateTime _startTime;
     private bool _isTiming;
+
+    private List<string> _sentences = new();
+    private int _currentSentenceIndex;
+
+    private int _accumulatedMistakes;
+    private int _accumulatedWords;
+    private string _allTypedText = string.Empty;
 
     [ObservableProperty]
     private string _targetText;
@@ -31,12 +39,15 @@ public partial class TextExerciseViewModel : BaseViewModel
 
     [ObservableProperty]
     private string _wpmDisplay = "Current Words Per Minute: 0";
-    
+
     [ObservableProperty]
     private string _mistakeCountDisplay = "Mistakes: 0";
 
     [ObservableProperty]
     private string _accuracyDisplay = "Accuracy: 100%";
+
+    [ObservableProperty]
+    private string _progressDisplay = "Sentence: 0/0";
 
     [ObservableProperty]
     private string _resultMessage;
@@ -53,9 +64,8 @@ public partial class TextExerciseViewModel : BaseViewModel
     [ObservableProperty]
     private string _completeMessage;
 
-    private bool _wasCorrect;
-
     public event Action<List<LetterStatus>> RequestLetterUpdate;
+    public event Action<string, string, string> OnLineChanged;
 
     public TextExerciseViewModel(
         ITextRepository textRepository,
@@ -83,33 +93,104 @@ public partial class TextExerciseViewModel : BaseViewModel
         IsTurnOverlayVisible = false;
         IsNotTurnOverlayVisible = true;
 
+        _accumulatedMistakes = 0;
+        _accumulatedWords = 0;
+        _allTypedText = string.Empty;
+        _statsService.ResetMistakes();
+
         LoadNewText();
     }
 
     private void LoadNewText()
     {
-        TargetText = _textRepository.GetRandomText();
-        _typeControl.TargetText = TargetText;
-        _typeControl.TypedText = string.Empty;
-        _statsService.ResetMistakes();
-        InputText = string.Empty;
-        TypedText = string.Empty;
+        string fullText = _textRepository.GetRandomText();
+        _sentences = SplitTextIntoSentences(fullText);
 
-        RequestLetterUpdate?.Invoke(_typeControl.GetLetterStatuses());
+        if (_sentences.Count == 0)
+        {
+            _sentences.Add("Error loading text. Please try again.");
+        }
+
+        _currentSentenceIndex = 0;
+        LoadCurrentSentence();
+    }
+
+    private List<string> SplitTextIntoSentences(string text)
+    {
+        var sentences = new List<string>();
+        string pattern = @"(?<=[.!?])\s+";
+        var parts = Regex.Split(text, pattern);
+
+        foreach (var part in parts)
+        {
+            if (!string.IsNullOrWhiteSpace(part))
+                sentences.Add(part.Trim());
+        }
+        return sentences;
+    }
+
+    private void LoadCurrentSentence()
+    {
+        if (_currentSentenceIndex < _sentences.Count)
+        {
+            TargetText = _sentences[_currentSentenceIndex];
+            _typeControl.TargetText = TargetText;
+            _typeControl.TypedText = string.Empty;
+
+            InputText = string.Empty;
+            TypedText = string.Empty;
+
+            string prev = _currentSentenceIndex > 0 ? _sentences[_currentSentenceIndex - 1] : "";
+            string next = _currentSentenceIndex + 1 < _sentences.Count ? _sentences[_currentSentenceIndex + 1] : "";
+
+            OnLineChanged?.Invoke(prev, TargetText, next);
+            ProgressDisplay = $"Sentence: {_currentSentenceIndex + 1}/{_sentences.Count}";
+
+            RequestLetterUpdate?.Invoke(_typeControl.GetLetterStatuses());
+        }
+        else
+        {
+            CompleteTyping();
+        }
     }
 
     partial void OnTypedTextChanged(string value)
     {
+        if (string.IsNullOrEmpty(TargetText)) return;
+
         if (!_isTiming && !string.IsNullOrEmpty(value))
         {
             StartTimer();
         }
 
-        _typeControl.CheckTyping(value ?? string.Empty);
-        
-        // Track mistakes as the user types
-        _statsService.TrackMistakes(value ?? string.Empty, TargetText);
+        string safeValue = value ?? string.Empty;
+
+        _typeControl.CheckTyping(safeValue);
+        _statsService.TrackMistakes(safeValue, TargetText);
+
         RequestLetterUpdate?.Invoke(_typeControl.GetLetterStatuses());
+
+        if (safeValue.Length >= TargetText.Length)
+        {
+            CompleteSentence();
+        }
+    }
+
+    private void CompleteSentence()
+    {
+        _accumulatedMistakes += _statsService.GetMistakeCount();
+        _accumulatedWords += CountWords(TargetText);
+        _allTypedText += TypedText + " ";
+
+        _statsService.ResetMistakes();
+
+        _currentSentenceIndex++;
+        LoadCurrentSentence();
+    }
+
+    private int CountWords(string text)
+    {
+        return string.IsNullOrWhiteSpace(text) ? 0 : text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
     }
 
     private void StartTimer()
@@ -132,13 +213,23 @@ public partial class TextExerciseViewModel : BaseViewModel
             var elapsed = DateTime.Now - _startTime;
             TimeDisplay = $"Current time: {elapsed.TotalSeconds:F2}s";
 
-            double wpm = _statsService.CalculateWordsPerMinuteText(TypedText ?? string.Empty, elapsed);
+            int currentWords = CountWords(TypedText);
+            int totalWords = _accumulatedWords + currentWords;
+            double wpm = elapsed.TotalMinutes > 0 ? totalWords / elapsed.TotalMinutes : 0;
+
             WpmDisplay = $"Current words per minute: {wpm:F2}";
 
-            int mistakeCount = _statsService.GetMistakeCount();
-            MistakeCountDisplay = $"Mistakes: {mistakeCount}";
+            int currentMistakes = _statsService.GetMistakeCount();
+            int totalMistakes = _accumulatedMistakes + currentMistakes;
+            MistakeCountDisplay = $"Mistakes: {totalMistakes}";
 
-            int accuracy = _statsService.CalculateAccuracy();
+            int totalChars = _allTypedText.Length + (TypedText?.Length ?? 0);
+            int accuracy = 100;
+            if (totalChars > 0)
+            {
+                double errorRate = (double)totalMistakes / totalChars;
+                accuracy = Math.Max(0, (int)((1 - errorRate) * 100));
+            }
             AccuracyDisplay = $"Accuracy: {accuracy}%";
         }
     }
@@ -148,17 +239,23 @@ public partial class TextExerciseViewModel : BaseViewModel
     {
         StopTimer();
         var elapsed = DateTime.Now - _startTime;
-        double wpm = _statsService.CalculateWordsPerMinuteText(TypedText ?? string.Empty, elapsed);
-        int mistakeCount = _statsService.GetMistakeCount();
-        int accuracy = _statsService.CalculateAccuracy();
 
+        double wpm = elapsed.TotalMinutes > 0 ? _accumulatedWords / elapsed.TotalMinutes : 0;
+
+        int totalChars = _allTypedText.Length;
+        int accuracy = 100;
+        if (totalChars > 0)
+        {
+            double errorRate = (double)_accumulatedMistakes / totalChars;
+            accuracy = Math.Max(0, (int)((1 - errorRate) * 100));
+        }
 
         TimeDisplay = $"Time: {elapsed.TotalSeconds:F2} seconds";
         WpmDisplay = $"Words Per Minute: {wpm:F2}";
-        MistakeCountDisplay = $"Mistakes: {mistakeCount}";
+        MistakeCountDisplay = $"Mistakes: {_accumulatedMistakes}";
         AccuracyDisplay = $"Accuracy: {accuracy}%";
 
-        CompleteMessage = $"Exercise Complete!\n\nTime: {elapsed.TotalSeconds:F2}s\nWPM: {wpm:F2}\nMistakes: {mistakeCount}\nAccuracy: {accuracy}%\n\nPress Enter to continue";
+        CompleteMessage = $"Exercise Complete!\n\nTime: {elapsed.TotalSeconds:F2}s\nWPM: {wpm:F2}\nMistakes: {_accumulatedMistakes}\nAccuracy: {accuracy}%\n\nPress Enter to continue";
 
         // Always show result overlay
         IsTurnOverlayVisible = true;
@@ -171,11 +268,6 @@ public partial class TextExerciseViewModel : BaseViewModel
         // Hide overlay
         IsTurnOverlayVisible = false;
         IsNotTurnOverlayVisible = true;
-
-        // Load new text for next exercise
-        LoadNewText();
-
-        _isTiming = false;
-        ResultMessage = string.Empty;
+        InitializeExercise();
     }
 }

--- a/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
@@ -189,7 +189,7 @@ public partial class TextExerciseViewModel : BaseViewModel
         _isTransitioning = true;
 
         _accumulatedMistakes += _statsService.GetMistakeCount();
-        _accumulatedWords += CountWords(TargetText);
+        _accumulatedWords += _textRepository.CountWords(TargetText);
         _allTypedText += TypedText + " ";
 
         _statsService.ResetMistakes();
@@ -206,11 +206,6 @@ public partial class TextExerciseViewModel : BaseViewModel
             LoadCurrentSentence();
             _isTransitioning = false;
         });
-    }
-
-    private int CountWords(string text)
-    {
-        return string.IsNullOrWhiteSpace(text) ? 0 : text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
     }
 
     private void StartTimer()
@@ -234,7 +229,7 @@ public partial class TextExerciseViewModel : BaseViewModel
         var elapsed = DateTime.Now - _startTime;
         TimeDisplay = $"Current time: {elapsed.TotalSeconds:F2}s";
 
-        int currentWords = CountWords(TypedText);
+        int currentWords = _textRepository.CountWords(TypedText);
         int totalWords = _accumulatedWords + currentWords;
         double wpm = elapsed.TotalMinutes > 0 ? totalWords / elapsed.TotalMinutes : 0;
 

--- a/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
@@ -233,7 +233,7 @@ public partial class TextExerciseViewModel : BaseViewModel
         int totalWords = _accumulatedWords + currentWords;
         double wpm = elapsed.TotalMinutes > 0 ? totalWords / elapsed.TotalMinutes : 0;
 
-        WpmDisplay = $"Current words per minute: {wpm:F0}"; // Reduced decimal places
+        WpmDisplay = $"Current words per minute: {wpm:F2}";
 
         int currentMistakes = _statsService.GetMistakeCount();
         int totalMistakes = _accumulatedMistakes + currentMistakes;

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml
@@ -16,9 +16,21 @@
                 HorizontalOptions="Center">
 
                 <Label
-                    x:Name="PracticeTextLabel"
+                    x:Name="PreviousLineLabel"
                     HorizontalOptions="Center"
-                    MaximumWidthRequest="500"/>
+                    TextColor="Transparent"
+                    MaximumWidthRequest="700"/>
+
+                <Label
+                    x:Name="CurrentLineLabel"
+                    HorizontalOptions="Center"
+                    MaximumWidthRequest="700"/>
+
+                <Label
+                    x:Name="NextLineLabel"
+                    HorizontalOptions="Center"
+                    TextColor="DimGray"
+                    MaximumWidthRequest="700"/>
 
                 <Label
                     x:Name="TypedTextLabel"
@@ -32,8 +44,8 @@
                     x:Name="InputEntry"
                     TextChanged="OnTextChanged"
                     Opacity="0"
-                    Text="{Binding InputText}"
-                    Placeholder="Copy text above and press enter when finished"
+                    Text="{Binding InputText, Mode=TwoWay}"
+                    Placeholder="Type text..."
                     ReturnCommand="{Binding CompleteTypingCommand}"
                     MaximumHeightRequest="1">
                 </Entry>
@@ -53,6 +65,10 @@
 
                 <Label
                     Text="{Binding AccuracyDisplay}"
+                    HorizontalOptions="Center"/>
+
+                <Label
+                    Text="{Binding ProgressDisplay}"
                     HorizontalOptions="Center"/>
             </VerticalStackLayout>
         </ScrollView>

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
@@ -11,6 +11,7 @@ public partial class TextExercise : ContentPage
     private List<LetterStatus>? _pendingStatuses;
     private List<Span> _currentLineSpans = new();
     private FormattedString? _currentLineFormatted;
+    private string _currentLineText = string.Empty;
     private bool _isUpdatingLetters; // Prevent concurrent updates
 
     public TextExercise(TextExerciseViewModel viewModel)
@@ -60,28 +61,13 @@ public partial class TextExercise : ContentPage
                 PreviousLineLabel.Text = prev;
                 NextLineLabel.Text = next;
 
-                // Pre-allocate with capacity for better performance
-                _currentLineFormatted = new FormattedString();
-                _currentLineSpans = new List<Span>(curr?.Length ?? 0);
+                // Store the text in our variable
+                _currentLineText = curr ?? string.Empty;
 
-                if (!string.IsNullOrEmpty(curr))
-                {
-                    double fontSize = CurrentLineLabel.FontSize;
+                // Clear FormattedText first to ensure Text displays
+                CurrentLineLabel.FormattedText = null;
+                CurrentLineLabel.Text = _currentLineText;
 
-                    foreach (char c in curr)
-                    {
-                        var span = new Span
-                        {
-                            Text = c.ToString(),
-                            TextColor = Colors.Gray,
-                            FontSize = fontSize
-                        };
-                        _currentLineSpans.Add(span);
-                        _currentLineFormatted.Spans.Add(span);
-                    }
-                }
-
-                CurrentLineLabel.FormattedText = _currentLineFormatted;
                 TypedTextLabel.Text = string.Empty;
             }
             catch (Exception ex)
@@ -93,58 +79,59 @@ public partial class TextExercise : ContentPage
 
     private void UpdateLetterDisplay(List<LetterStatus> statuses)
     {
-        // If an update is already running, save this one for later and return
-        if (_isUpdatingLetters)
-        {
-            _pendingStatuses = statuses;
-            return;
-        }
-
+        if (_isUpdatingLetters) return;
         _isUpdatingLetters = true;
-        _pendingStatuses = null; // Clear pending since we are processing one now
 
         MainThread.BeginInvokeOnMainThread(() =>
         {
             try
             {
-                if (_currentLineSpans == null || _currentLineSpans.Count == 0 || statuses == null)
+                // USE THE VARIABLE HERE, NOT THE LABEL
+                string fullText = _currentLineText;
+
+                if (string.IsNullOrEmpty(fullText) || statuses == null || statuses.Count == 0)
                 {
-                    // _isUpdatingLetters will be reset in finally block
+                    // If we have text but no statuses yet, just show the plain text
+                    if (!string.IsNullOrEmpty(fullText))
+                    {
+                        CurrentLineLabel.FormattedText = null;
+                        CurrentLineLabel.Text = fullText;
+                    }
                     return;
                 }
 
-                int limit = Math.Min(statuses.Count, _currentLineSpans.Count);
+                var newFormattedString = new FormattedString();
 
-                for (int i = 0; i < limit; i++)
+                var currentStatus = statuses[0].Status;
+                int startIndex = 0;
+
+                for (int i = 1; i < statuses.Count; i++)
                 {
-                    var status = statuses[i];
-                    var span = _currentLineSpans[i];
-
-                    // Optimization from Step 2
-                    if (status.Status == Status.Pending &&
-                        span.TextColor == Colors.Gray &&
-                        span.TextDecorations == TextDecorations.None)
+                    if (statuses[i].Status != currentStatus)
                     {
-                        break;
+                        int length = i - startIndex;
+                        // Safely extract substring
+                        if (startIndex + length <= fullText.Length)
+                        {
+                            string segment = fullText.Substring(startIndex, length);
+                            newFormattedString.Spans.Add(CreateSpan(segment, currentStatus));
+                        }
+
+                        currentStatus = statuses[i].Status;
+                        startIndex = i;
                     }
-
-                    Color targetColor = status.Status switch
-                    {
-                        Status.Correct => Colors.Green,
-                        Status.Incorrect => Colors.Red,
-                        _ => Colors.Gray
-                    };
-
-                    TextDecorations targetDecoration = status.Status == Status.Incorrect
-                        ? TextDecorations.Underline
-                        : TextDecorations.None;
-
-                    if (span.TextColor != targetColor)
-                        span.TextColor = targetColor;
-
-                    if (span.TextDecorations != targetDecoration)
-                        span.TextDecorations = targetDecoration;
                 }
+
+                // Add remaining text
+                if (startIndex < fullText.Length)
+                {
+                    string remainingText = fullText.Substring(startIndex);
+                    newFormattedString.Spans.Add(CreateSpan(remainingText, currentStatus));
+                }
+
+                // Apply the new formatting
+                CurrentLineLabel.Text = null; // Clear plain text
+                CurrentLineLabel.FormattedText = newFormattedString;
             }
             catch (Exception ex)
             {
@@ -153,17 +140,29 @@ public partial class TextExercise : ContentPage
             finally
             {
                 _isUpdatingLetters = false;
-
-                // Check if a new update arrived while we were busy
-                if (_pendingStatuses != null)
-                {
-                    var nextUpdate = _pendingStatuses;
-                    _pendingStatuses = null;
-                    // Recursively call to process the pending update
-                    UpdateLetterDisplay(nextUpdate);
-                }
             }
         });
+    }
+
+    // Helper method to keep style consistent
+    private Span CreateSpan(string text, Status status)
+    {
+        var span = new Span { Text = text, FontSize = CurrentLineLabel.FontSize };
+
+        switch (status)
+        {
+            case Status.Correct:
+                span.TextColor = Colors.Green;
+                break;
+            case Status.Incorrect:
+                span.TextColor = Colors.Red;
+                span.TextDecorations = TextDecorations.Underline;
+                break;
+            default: // Pending
+                span.TextColor = Colors.Gray;
+                break;
+        }
+        return span;
     }
 
     private void FocusEntry(Entry entry)

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
@@ -9,7 +9,8 @@ public partial class TextExercise : ContentPage
     private readonly TextExerciseViewModel _viewModel;
 
     private List<Span> _currentLineSpans = new();
-    private FormattedString _currentLineFormatted;
+    private FormattedString? _currentLineFormatted;
+    private bool _isUpdatingLetters; // Prevent concurrent updates
 
     public TextExercise(TextExerciseViewModel viewModel)
     {
@@ -29,7 +30,16 @@ public partial class TextExercise : ContentPage
         FocusEntry(InputEntry);
     }
 
-    private void OnViewModelPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        // Clean up event handlers to prevent memory leaks
+        _viewModel.RequestLetterUpdate -= UpdateLetterDisplay;
+        _viewModel.OnLineChanged -= UpdateLineDisplay;
+        _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(_viewModel.IsTurnOverlayVisible))
         {
@@ -44,62 +54,94 @@ public partial class TextExercise : ContentPage
     {
         MainThread.BeginInvokeOnMainThread(() =>
         {
-            PreviousLineLabel.Text = prev;
-            NextLineLabel.Text = next;
-
-            _currentLineFormatted = new FormattedString();
-            _currentLineSpans.Clear();
-
-            if (!string.IsNullOrEmpty(curr))
+            try
             {
-                foreach (char c in curr)
-                {
-                    var span = new Span
-                    {
-                        Text = c.ToString(),
-                        TextColor = Colors.Gray,
-                        FontSize = CurrentLineLabel.FontSize
-                    };
-                    _currentLineSpans.Add(span);
-                    _currentLineFormatted.Spans.Add(span);
-                }
-            }
+                PreviousLineLabel.Text = prev;
+                NextLineLabel.Text = next;
 
-            CurrentLineLabel.FormattedText = _currentLineFormatted;
-            TypedTextLabel.Text = string.Empty;
+                // Pre-allocate with capacity for better performance
+                _currentLineFormatted = new FormattedString();
+                _currentLineSpans = new List<Span>(curr?.Length ?? 0);
+
+                if (!string.IsNullOrEmpty(curr))
+                {
+                    double fontSize = CurrentLineLabel.FontSize;
+
+                    foreach (char c in curr)
+                    {
+                        var span = new Span
+                        {
+                            Text = c.ToString(),
+                            TextColor = Colors.Gray,
+                            FontSize = fontSize
+                        };
+                        _currentLineSpans.Add(span);
+                        _currentLineFormatted.Spans.Add(span);
+                    }
+                }
+
+                CurrentLineLabel.FormattedText = _currentLineFormatted;
+                TypedTextLabel.Text = string.Empty;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"UpdateLineDisplay error: {ex.Message}");
+            }
         });
     }
 
     private void UpdateLetterDisplay(List<LetterStatus> statuses)
     {
+        // Prevent concurrent updates which can cause freezing
+        if (_isUpdatingLetters)
+            return;
+
+        _isUpdatingLetters = true;
+
         MainThread.BeginInvokeOnMainThread(() =>
         {
-            if (_currentLineSpans == null || _currentLineSpans.Count == 0) return;
-            if (statuses == null) return;
-
-            int limit = Math.Min(statuses.Count, _currentLineSpans.Count);
-
-            for (int i = 0; i < limit; i++)
+            try
             {
-                var status = statuses[i];
-                var span = _currentLineSpans[i];
-
-                var targetColor = status.Status switch
+                if (_currentLineSpans == null || _currentLineSpans.Count == 0 || statuses == null)
                 {
-                    Status.Correct => Colors.Green,
-                    Status.Incorrect => Colors.Red,
-                    _ => Colors.Gray
-                };
+                    _isUpdatingLetters = false;
+                    return;
+                }
 
-                var targetDecoration = status.Status == Status.Incorrect
-                    ? TextDecorations.Underline
-                    : TextDecorations.None;
+                int limit = Math.Min(statuses.Count, _currentLineSpans.Count);
 
-                if (span.TextColor != targetColor)
-                    span.TextColor = targetColor;
+                for (int i = 0; i < limit; i++)
+                {
+                    var status = statuses[i];
+                    var span = _currentLineSpans[i];
 
-                if (span.TextDecorations != targetDecoration)
-                    span.TextDecorations = targetDecoration;
+                    // Determine target values
+                    Color targetColor = status.Status switch
+                    {
+                        Status.Correct => Colors.Green,
+                        Status.Incorrect => Colors.Red,
+                        _ => Colors.Gray
+                    };
+
+                    TextDecorations targetDecoration = status.Status == Status.Incorrect
+                        ? TextDecorations.Underline
+                        : TextDecorations.None;
+
+                    // Only update if changed - reduces UI work
+                    if (span.TextColor != targetColor)
+                        span.TextColor = targetColor;
+
+                    if (span.TextDecorations != targetDecoration)
+                        span.TextDecorations = targetDecoration;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"UpdateLetterDisplay error: {ex.Message}");
+            }
+            finally
+            {
+                _isUpdatingLetters = false;
             }
         });
     }
@@ -108,30 +150,30 @@ public partial class TextExercise : ContentPage
     {
         Dispatcher.Dispatch(async () =>
         {
-            await Task.Delay(100); // Small delay to ensure UI is rendered
+            await Task.Delay(100);
             entry.Focus();
         });
     }
 
-    private void OnTextChanged(object sender, TextChangedEventArgs e)
+    private void OnTextChanged(object? sender, TextChangedEventArgs e)
     {
         string currentText = e.NewTextValue ?? string.Empty;
         string oldText = e.OldTextValue ?? string.Empty;
 
-        // Check if text was added 
+        // Update TypedTextLabel based on what was added
         if (currentText.Length == 0)
         {
             TypedTextLabel.Text = "";
         }
         else if (currentText.Length > oldText.Length)
         {
-            // Get the newly added characters
+            // Append only the newly added characters
             string addedText = currentText.Substring(oldText.Length);
-            // Append to the label
             TypedTextLabel.Text += addedText;
         }
+        // Note: We don't handle deletion in TypedTextLabel since it's display-only
 
-        // Update ViewModel to compare based on TypedTextLabel content
+        // Update ViewModel - this triggers the typing check
         _viewModel.TypedText = TypedTextLabel.Text ?? string.Empty;
     }
 }

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
@@ -8,6 +8,7 @@ public partial class TextExercise : ContentPage
 {
     private readonly TextExerciseViewModel _viewModel;
 
+    private List<LetterStatus>? _pendingStatuses;
     private List<Span> _currentLineSpans = new();
     private FormattedString? _currentLineFormatted;
     private bool _isUpdatingLetters; // Prevent concurrent updates
@@ -92,11 +93,15 @@ public partial class TextExercise : ContentPage
 
     private void UpdateLetterDisplay(List<LetterStatus> statuses)
     {
-        // Prevent concurrent updates which can cause freezing
+        // If an update is already running, save this one for later and return
         if (_isUpdatingLetters)
+        {
+            _pendingStatuses = statuses;
             return;
+        }
 
         _isUpdatingLetters = true;
+        _pendingStatuses = null; // Clear pending since we are processing one now
 
         MainThread.BeginInvokeOnMainThread(() =>
         {
@@ -104,7 +109,7 @@ public partial class TextExercise : ContentPage
             {
                 if (_currentLineSpans == null || _currentLineSpans.Count == 0 || statuses == null)
                 {
-                    _isUpdatingLetters = false;
+                    // _isUpdatingLetters will be reset in finally block
                     return;
                 }
 
@@ -115,7 +120,14 @@ public partial class TextExercise : ContentPage
                     var status = statuses[i];
                     var span = _currentLineSpans[i];
 
-                    // Determine target values
+                    // Optimization from Step 2
+                    if (status.Status == Status.Pending &&
+                        span.TextColor == Colors.Gray &&
+                        span.TextDecorations == TextDecorations.None)
+                    {
+                        break;
+                    }
+
                     Color targetColor = status.Status switch
                     {
                         Status.Correct => Colors.Green,
@@ -127,7 +139,6 @@ public partial class TextExercise : ContentPage
                         ? TextDecorations.Underline
                         : TextDecorations.None;
 
-                    // Only update if changed - reduces UI work
                     if (span.TextColor != targetColor)
                         span.TextColor = targetColor;
 
@@ -142,6 +153,15 @@ public partial class TextExercise : ContentPage
             finally
             {
                 _isUpdatingLetters = false;
+
+                // Check if a new update arrived while we were busy
+                if (_pendingStatuses != null)
+                {
+                    var nextUpdate = _pendingStatuses;
+                    _pendingStatuses = null;
+                    // Recursively call to process the pending update
+                    UpdateLetterDisplay(nextUpdate);
+                }
             }
         });
     }

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
@@ -8,6 +8,9 @@ public partial class TextExercise : ContentPage
 {
     private readonly TextExerciseViewModel _viewModel;
 
+    private List<Span> _currentLineSpans = new();
+    private FormattedString _currentLineFormatted;
+
     public TextExercise(TextExerciseViewModel viewModel)
     {
         InitializeComponent();
@@ -15,6 +18,7 @@ public partial class TextExercise : ContentPage
         BindingContext = _viewModel;
 
         _viewModel.RequestLetterUpdate += UpdateLetterDisplay;
+        _viewModel.OnLineChanged += UpdateLineDisplay;
         _viewModel.PropertyChanged += OnViewModelPropertyChanged;
     }
 
@@ -30,47 +34,74 @@ public partial class TextExercise : ContentPage
         if (e.PropertyName == nameof(_viewModel.IsTurnOverlayVisible))
         {
             if (_viewModel.IsTurnOverlayVisible)
-            {
                 FocusEntry(Invisible);
-            }
             else
-            {
                 FocusEntry(InputEntry);
-            }
         }
+    }
+
+    private void UpdateLineDisplay(string prev, string curr, string next)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            PreviousLineLabel.Text = prev;
+            NextLineLabel.Text = next;
+
+            _currentLineFormatted = new FormattedString();
+            _currentLineSpans.Clear();
+
+            if (!string.IsNullOrEmpty(curr))
+            {
+                foreach (char c in curr)
+                {
+                    var span = new Span
+                    {
+                        Text = c.ToString(),
+                        TextColor = Colors.Gray,
+                        FontSize = CurrentLineLabel.FontSize
+                    };
+                    _currentLineSpans.Add(span);
+                    _currentLineFormatted.Spans.Add(span);
+                }
+            }
+
+            CurrentLineLabel.FormattedText = _currentLineFormatted;
+            TypedTextLabel.Text = string.Empty;
+        });
     }
 
     private void UpdateLetterDisplay(List<LetterStatus> statuses)
     {
-        var formattedString = new FormattedString();
-
-        foreach (var letterStatus in statuses)
+        MainThread.BeginInvokeOnMainThread(() =>
         {
-            var span = new Span
+            if (_currentLineSpans == null || _currentLineSpans.Count == 0) return;
+            if (statuses == null) return;
+
+            int limit = Math.Min(statuses.Count, _currentLineSpans.Count);
+
+            for (int i = 0; i < limit; i++)
             {
-                Text = letterStatus.Character.ToString(),
-                FontSize = PracticeTextLabel.FontSize
-            };
+                var status = statuses[i];
+                var span = _currentLineSpans[i];
 
-            span.TextColor = letterStatus.Status switch
-            {
-                Status.Correct => Colors.Green,
-                Status.Incorrect => Colors.Red,
-                Status.Pending => Colors.Gray,
-                _ => Colors.Black
-            };
+                var targetColor = status.Status switch
+                {
+                    Status.Correct => Colors.Green,
+                    Status.Incorrect => Colors.Red,
+                    _ => Colors.Gray
+                };
 
-            span.TextDecorations = letterStatus.Status switch
-            {
-                Status.Correct => TextDecorations.None,
-                Status.Incorrect => TextDecorations.Underline,
-                _ => TextDecorations.None
-            };
+                var targetDecoration = status.Status == Status.Incorrect
+                    ? TextDecorations.Underline
+                    : TextDecorations.None;
 
-            formattedString.Spans.Add(span);
-        }
+                if (span.TextColor != targetColor)
+                    span.TextColor = targetColor;
 
-        PracticeTextLabel.FormattedText = formattedString;
+                if (span.TextDecorations != targetDecoration)
+                    span.TextDecorations = targetDecoration;
+            }
+        });
     }
 
     private void FocusEntry(Entry entry)
@@ -88,11 +119,14 @@ public partial class TextExercise : ContentPage
         string oldText = e.OldTextValue ?? string.Empty;
 
         // Check if text was added 
-        if (currentText.Length > oldText.Length)
+        if (currentText.Length == 0)
+        {
+            TypedTextLabel.Text = "";
+        }
+        else if (currentText.Length > oldText.Length)
         {
             // Get the newly added characters
             string addedText = currentText.Substring(oldText.Length);
-
             // Append to the label
             TypedTextLabel.Text += addedText;
         }

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/VersusResultView.xaml
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/VersusResultView.xaml
@@ -29,7 +29,7 @@
                     </VerticalStackLayout>
 
                     <Label Text="{Binding Player1Result.PlayerName}" Style="{StaticResource SubHeadline}"/>
-                    <Label Text="{Binding Player1Result.WordsPerMinute, StringFormat='WPM: {0:F0}'}" FontAttributes="Bold"/>
+                    <Label Text="{Binding Player1Result.WordsPerMinute, StringFormat='WPM: {0:F2}'}" FontAttributes="Bold"/>
                     <Label Text="{Binding Player1Result.Errors, StringFormat='Errors: {0}'}"/>
                     <Label Text="{Binding Player1Result.TimeTaken, StringFormat='Time: {0:mm\\:ss}'}"/>
                 </VerticalStackLayout>
@@ -43,7 +43,7 @@
                     </VerticalStackLayout>
 
                     <Label Text="{Binding Player2Result.PlayerName}" Style="{StaticResource SubHeadline}"/>
-                    <Label Text="{Binding Player2Result.WordsPerMinute, StringFormat='WPM: {0:F0}'}" FontAttributes="Bold"/>
+                    <Label Text="{Binding Player2Result.WordsPerMinute, StringFormat='WPM: {0:F2}'}" FontAttributes="Bold"/>
                     <Label Text="{Binding Player2Result.Errors, StringFormat='Errors: {0}'}"/>
                     <Label Text="{Binding Player2Result.TimeTaken, StringFormat='Time: {0:mm\\:ss}'}"/>
                 </VerticalStackLayout>

--- a/LearnQuickTyping/LearnQuickTyping.Core.Data/Repositories/TextRepository.cs
+++ b/LearnQuickTyping/LearnQuickTyping.Core.Data/Repositories/TextRepository.cs
@@ -23,7 +23,11 @@ public class TextRepository : ITextRepository
     {
         var random = new Random();
         int index = random.Next(_practiceTexts.Length);
-        return _practiceTexts[index];
+        return _practiceTexts[index]
+            .Replace("“", "\"") // Opening double quote
+            .Replace("”", "\"") // Closing double quote
+            .Replace("’", "'")  // Right single quote
+            .Replace("‘", "'"); // Left single quote
     }
     public int GetWordCount()
     {

--- a/LearnQuickTyping/LearnQuickTyping.Core/Models/LetterStatus.cs
+++ b/LearnQuickTyping/LearnQuickTyping.Core/Models/LetterStatus.cs
@@ -1,6 +1,6 @@
 ﻿namespace LearnQuickTyping.Core.Models;
 
-public class LetterStatus
+public struct LetterStatus
 {
     public char Character { get; set; }
     public Status Status { get; set; }

--- a/LearnQuickTyping/LearnQuickTyping.Core/Services/TypeControlService.cs
+++ b/LearnQuickTyping/LearnQuickTyping.Core/Services/TypeControlService.cs
@@ -15,7 +15,7 @@ public class TypeControlService : ITypeControlService
 
     public List<LetterStatus> GetLetterStatuses()
     {
-        var statuses = new List<LetterStatus>();
+        var statuses = new List<LetterStatus>(TargetText.Length);
 
         for (int i = 0; i < TargetText.Length; i++)
         {


### PR DESCRIPTION
# Feature: Sentence-based Text Exercise (UC1-US1)

## Description

This PR implements User Story 1 (UC1-US1), refactoring the **Text Exercise** module to process text sentence-by-sentence rather than as a single block. 

Previously, the user typed the entire random text at once. The new implementation splits the text into sentences, clearing the input field after each sentence is completed while accumulating statistics (WPM, Accuracy, Mistakes) across the entire session. 

##  Key Changes

### `TextExerciseViewModel.cs`
- **Sentence Segmentation**: Implemented `SplitTextIntoSentences` using Regex to break down raw text based on punctuation (`.!?`).
- **Sequential Typing Workflow**: 
  - Added `LoadCurrentSentence()` to serve one sentence at a time.
  - Added `CompleteSentence()` to handle transitions: it accumulates stats, clears the input, and triggers the next sentence.
  - Logic added to detect when a sentence is fully typed to automatically advance.
- **Statistics Accumulation**:
  - Introduced `_accumulatedMistakes`, `_accumulatedWords`, and `_allTypedText` to track progress across multiple sentences.
  - Updated `OnTimerTick` and `CompleteTyping` to calculate WPM and Accuracy based on the cumulative session data rather than just the current input field.
- **New Properties & Events**:
  - Added `ProgressDisplay` (e.g., "Sentence: 1/5").
  - Added `OnLineChanged` event to notify the View of the Previous, Current, and Next sentences (enabling a multi-line preview).
- **Optimization**: Reduced timer tick frequency from 50ms to 100ms.

### `TypeControlService.cs`
- **Optimization**: Initialized `LetterStatus` list with a defined capacity to improve memory allocation performance during rapid typing.

##  Related User Stories
* **UC1_US1**: As a user, I want to practice typing text sentence by sentence so that I can focus on smaller chunks of content.