### PR TITLE
Feature/UC1_US6

### DIFF
--- a/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
@@ -6,6 +6,7 @@ using LearnQuickTyping.Core.Interfaces.Services;
 using LearnQuickTyping.Core.Models;
 using System.Text.RegularExpressions;
 using LearnQuickTyping.App.Views;
+using Microsoft.Maui.Layouts;
 
 
 namespace LearnQuickTyping.App.ViewModels;
@@ -30,6 +31,8 @@ public partial class TextExerciseViewModel : BaseViewModel
 
     // Temporary result
     private TextResult? _result;
+
+    public event Action? RequestInputFocus;
 
     [ObservableProperty]
     private string _targetText = string.Empty;
@@ -62,10 +65,10 @@ public partial class TextExerciseViewModel : BaseViewModel
     private Color _resultColor = Colors.Black;
 
     [ObservableProperty]
-    private bool _isStartScreenVisible = false;
+    private bool _isStartScreenVisible = true;
 
     [ObservableProperty]
-    private bool _isNotStartScreenVisible = true;
+    private bool _isNotStartScreenVisible = false;
 
     [ObservableProperty]
     private string _completeMessage = string.Empty;
@@ -100,6 +103,8 @@ public partial class TextExerciseViewModel : BaseViewModel
         InputText = string.Empty;
         TypedText = string.Empty;
         ResultMessage = string.Empty;
+
+        // Force property change to trigger focus
         IsStartScreenVisible = false;
         IsNotStartScreenVisible = true;
 
@@ -109,6 +114,10 @@ public partial class TextExerciseViewModel : BaseViewModel
         _statsService.ResetMistakes();
 
         LoadNewText();
+
+        // Now set it back to show the start screen and trigger PropertyChanged
+        IsStartScreenVisible = true;
+        IsNotStartScreenVisible = false;
 
         _isTransitioning = false;
     }
@@ -308,6 +317,5 @@ public partial class TextExerciseViewModel : BaseViewModel
     {
         IsStartScreenVisible = false;
         IsNotStartScreenVisible = true;
-        InitializeExercise();
     }
 }

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml
@@ -81,13 +81,18 @@
                 Spacing="20">
 
                 <Label 
-                    Text="{Binding ResultMessage}"
+                    Text="Press Enter to start"
                     Style="{StaticResource Headline}"
                     HorizontalTextAlignment="Center"/>
 
                 <Label 
-                    Text="{Binding CompleteMessage}"
-                    Style="{StaticResource Headline}"
+                    Text="The exercise will start once you start typing"
+                    Style="{StaticResource SubHeadline}"
+                    HorizontalTextAlignment="Center"/>
+
+                <Label 
+                    Text="When you are done typing, press Enter to finish the exercise"
+                    Style="{StaticResource SubHeadline}"
                     HorizontalTextAlignment="Center"/>
 
                 <Entry 

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
@@ -29,7 +29,11 @@ public partial class TextExercise : ContentPage
     {
         base.OnAppearing();
         _viewModel.InitializeExerciseCommand.Execute(null);
-        FocusEntry(InputEntry);
+
+        Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(100), () =>
+        {
+            Invisible.Focus();
+        });
     }
 
     protected override void OnDisappearing()
@@ -45,10 +49,17 @@ public partial class TextExercise : ContentPage
     {
         if (e.PropertyName == nameof(_viewModel.IsStartScreenVisible))
         {
-            if (_viewModel.IsStartScreenVisible)
-                FocusEntry(Invisible);
-            else
-                FocusEntry(InputEntry);
+            Dispatcher.DispatchDelayed(TimeSpan.FromMilliseconds(50), () =>
+            {
+                if (_viewModel.IsStartScreenVisible)
+                {
+                    Invisible.Focus();
+                }
+                else
+                {
+                    InputEntry.Focus();
+                }
+            });
         }
     }
 
@@ -163,15 +174,6 @@ public partial class TextExercise : ContentPage
                 break;
         }
         return span;
-    }
-
-    private void FocusEntry(Entry entry)
-    {
-        Dispatcher.Dispatch(async () =>
-        {
-            await Task.Delay(100);
-            entry.Focus();
-        });
     }
 
     private void OnTextChanged(object? sender, TextChangedEventArgs e)


### PR DESCRIPTION

This pull request updates the start screen and input focus behavior for the text exercise feature, improving the user experience when beginning or restarting an exercise. The main changes include adjusting the visibility logic for the start screen, updating the instructional messages, and refactoring how input focus is managed to ensure smoother transitions.

**Start screen logic and messaging improvements:**

* Changed the default values of `IsStartScreenVisible` and `IsNotStartScreenVisible` in `TextExerciseViewModel` to better control which screen is shown initially.
* Updated the start screen messages in `TextExercise.xaml` to provide clearer instructions for starting and completing the exercise.

**Input focus management and event handling:**

* Refactored input focus logic by removing the `FocusEntry` helper method and using delayed dispatches to set focus directly on the relevant entry controls, both on appearing and when the start screen visibility changes. 
* Added a `RequestInputFocus` event to `TextExerciseViewModel` for future extensibility in managing focus requests.

**Exercise initialization and transition handling:**

* Modified the `InitializeExercise` method to toggle visibility properties in a way that forces property change notifications, ensuring UI updates and input focus are triggered correctly. 
* Simplified the `StartExercise` method to only update visibility flags, removing redundant initialization logic.