### PR TITLE
Feature/UC05 prep into develop

### DIFF
--- a/LearnQuickTyping/LearnQuickTyping.App/AppShell.xaml.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/AppShell.xaml.cs
@@ -15,5 +15,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(Views.TextExerciseResultView), typeof(Views.TextExerciseResultView));
         Routing.RegisterRoute(nameof(Views.LyricsExercise), typeof(Views.LyricsExercise));
         Routing.RegisterRoute(nameof(Views.LyricsResult), typeof(Views.LyricsResult));
+        Routing.RegisterRoute(nameof(Views.DifficultySelectView), typeof(Views.DifficultySelectView));
     }
 }

--- a/LearnQuickTyping/LearnQuickTyping.App/LearnQuickTyping.App.csproj
+++ b/LearnQuickTyping/LearnQuickTyping.App/LearnQuickTyping.App.csproj
@@ -78,6 +78,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <MauiXaml Update="Views\DifficultySelectView.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Views\LyricsExercise.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/LearnQuickTyping/LearnQuickTyping.App/MauiProgram.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/MauiProgram.cs
@@ -52,6 +52,8 @@ public static class MauiProgram
         builder.Services.AddTransient<LyricsResult>();
         builder.Services.AddTransient<LyricsExercise>();
 
+        builder.Services.AddTransient<DifficultySelectView>();
+
 #if DEBUG
         builder.Logging.AddDebug();
 #endif

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/DifficultySelectView.xaml
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/DifficultySelectView.xaml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="LearnQuickTyping.App.Views.DifficultySelectView">
+
+    <ScrollView>
+        <VerticalStackLayout
+            Spacing="20"
+            Padding="20"
+            VerticalOptions="Center">
+
+            <Label
+                Text="Choose difficulty"
+                Style="{StaticResource Headline}" />
+
+            <Label 
+                Text="Choose a difficulty to get started"
+                Style="{StaticResource SubHeadline}"
+                HorizontalOptions="Center" />
+
+            <Button
+                Text="Beginner"
+                Clicked="OnBeginnerDifficultyClicked" />
+
+            <Button
+                Text="Intermediate"
+                Clicked="OnIntermediateDifficultyClicked" />
+
+            <Button
+                Text="Advanced"
+                Clicked="OnAdvancedDifficultyClicked" />
+
+            <Button
+                Text="Expert"
+                Clicked="OnExpertDifficultyClicked" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/DifficultySelectView.xaml
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/DifficultySelectView.xaml
@@ -20,20 +20,28 @@
 
             <Button
                 Text="Beginner"
-                Clicked="OnBeginnerDifficultyClicked" />
+                Clicked="OnBeginnerDifficultyClicked" 
+                MaximumWidthRequest="800"/>
 
             <Button
                 Text="Intermediate"
-                Clicked="OnIntermediateDifficultyClicked" />
+                Clicked="OnIntermediateDifficultyClicked"
+                MaximumWidthRequest="800"/>
 
             <Button
                 Text="Advanced"
-                Clicked="OnAdvancedDifficultyClicked" />
+                Clicked="OnAdvancedDifficultyClicked"
+                MaximumWidthRequest="800"/>
 
             <Button
                 Text="Expert"
-                Clicked="OnExpertDifficultyClicked" />
+                Clicked="OnExpertDifficultyClicked"
+                MaximumWidthRequest="800"/>
 
+            <Button
+                Text="Test Your Difficulty"
+                Clicked="OnIntroductionTextClicked"
+                MaximumWidthRequest="1200"/>
         </VerticalStackLayout>
     </ScrollView>
 </ContentPage>

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/DifficultySelectView.xaml.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/DifficultySelectView.xaml.cs
@@ -1,0 +1,29 @@
+namespace LearnQuickTyping.App.Views;
+
+public partial class DifficultySelectView : ContentPage
+{
+	public DifficultySelectView()
+	{
+		InitializeComponent();
+	}
+
+    private async void OnBeginnerDifficultyClicked(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync(nameof(TextExercise));
+    }
+
+    private async void OnIntermediateDifficultyClicked(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync(nameof(TextExercise));
+    }
+
+    private async void OnAdvancedDifficultyClicked(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync(nameof(TextExercise));
+    }
+
+    private async void OnExpertDifficultyClicked(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync(nameof(TextExercise));
+    }
+}

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/DifficultySelectView.xaml.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/DifficultySelectView.xaml.cs
@@ -26,4 +26,9 @@ public partial class DifficultySelectView : ContentPage
     {
         await Shell.Current.GoToAsync(nameof(TextExercise));
     }
+
+    private async void OnIntroductionTextClicked(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync(nameof(TextExercise));
+    }
 }

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/StartPage.xaml.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/StartPage.xaml.cs
@@ -14,7 +14,7 @@ public partial class StartPage : ContentPage
 
     private async void OnTextPracticeClicked(object sender, EventArgs e)
     {
-        await Shell.Current.GoToAsync(nameof(TextExercise));
+        await Shell.Current.GoToAsync(nameof(DifficultySelectView));
     }
 
     private async void OnVersusModeClicked(object sender, EventArgs e)


### PR DESCRIPTION
## Use Case 5: Select difficulty preperation

This pull request introduces a new difficulty selection feature for text exercises in the application. Instead of navigating directly to the text exercise, users are now presented with a screen to choose their desired difficulty level. The main changes include adding the new `DifficultySelectView`, updating navigation logic, and registering the new view in the app's routing and dependency injection systems. This is an early pull request to prevent merge conflicts later on.

**Feature Addition: Difficulty Selection**
* Added new view `DifficultySelectView` with buttons for Beginner, Intermediate, Advanced, Expert, and a test option. Each button navigates to the text exercise. (`DifficultySelectView.xaml`, `DifficultySelectView.xaml.cs`) [[1]](diffhunk://#diff-f273f6fbd0c0065d40ff32d7c592fa8567be2a3a8bf437e81fdc2b72000d6d19R1-R47) [[2]](diffhunk://#diff-b9f5f32874c8a1317b83ce29210d2c8e501e4010657b3b70a307fb16c080aeb6R1-R34)
* Registered `DifficultySelectView` as a route in the app shell to enable navigation. (`AppShell.xaml.cs`)
* Included `DifficultySelectView` in the project file for XAML compilation. (`LearnQuickTyping.App.csproj`)
* Registered `DifficultySelectView` for dependency injection to support transient creation. (`MauiProgram.cs`)

**Navigation Update**
* Changed the navigation flow for text practice: users are now taken to `DifficultySelectView` instead of directly to the text exercise. (`StartPage.xaml.cs`)