### PR TITLE
Feature/UC06_US03

### DIFF
--- a/LearnQuickTyping/LearnQuickTyping.App/ViewModels/ProgressViewModel.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/ViewModels/ProgressViewModel.cs
@@ -68,6 +68,32 @@ public partial class ProgressViewModel : BaseViewModel
         await Shell.Current.GoToAsync("///StartPage");
     }
 
+    [RelayCommand]
+    private async Task TryAgain(ExerciseResult result)
+    {
+        if (result == null) return;
+
+        try
+        {
+            // Navigate to the right exercise
+            string route = result.ExerciseType switch
+            {
+                ExerciseType.Word => nameof(Views.WordExercise),
+                ExerciseType.Text => $"{nameof(Views.TextExercise)}?difficulty={result.DifficultyLevel}",
+                ExerciseType.Versus => nameof(Views.VersusView),
+                ExerciseType.Lyrics => nameof(Views.LyricsExercise),
+                _ => "StartPage"
+            };
+
+            await Shell.Current.GoToAsync(route);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error loading exercise: {ex.Message}");
+            await Shell.Current.GoToAsync("///StartPage");
+        }
+    }
+
     // Helper properties for display formatting
     public static string FormatExerciseType(ExerciseType type) => type switch
     {

--- a/LearnQuickTyping/LearnQuickTyping.App/ViewModels/ProgressViewModel.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/ViewModels/ProgressViewModel.cs
@@ -81,7 +81,7 @@ public partial class ProgressViewModel : BaseViewModel
                 ExerciseType.Word => nameof(Views.WordExercise),
                 ExerciseType.Text => $"{nameof(Views.TextExercise)}?difficulty={result.DifficultyLevel}",
                 ExerciseType.Versus => nameof(Views.VersusView),
-                ExerciseType.Lyrics => nameof(Views.LyricsExercise),
+                ExerciseType.Karaoke => nameof(Views.LyricsExercise),
                 _ => "StartPage"
             };
 
@@ -100,7 +100,7 @@ public partial class ProgressViewModel : BaseViewModel
         ExerciseType.Word => "Word",
         ExerciseType.Text => "Text",
         ExerciseType.Versus => "Versus",
-        ExerciseType.Lyrics => "Karaoke",
+        ExerciseType.Karaoke => "Karaoke",
         _ => type.ToString()
     };
 

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/ProgressView.xaml
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/ProgressView.xaml
@@ -62,7 +62,7 @@
 
                 <Grid 
                     Grid.Row="0"
-                    ColumnDefinitions="*, 0.8*, 0.6*, 0.8*, 0.5*, 0.6*, 0.5*, 0.5*"
+                    ColumnDefinitions="*, 0.8*, 0.6*, 0.8*, 0.6*, 0.7*, 0.5*, 0.6*, 120"
                     Padding="10,5"
                     BackgroundColor="{StaticResource Gray900}">
                     <Label Grid.Column="0" Text="Date" FontAttributes="Bold" TextColor="{StaticResource White}"/>
@@ -73,6 +73,7 @@
                     <Label Grid.Column="5" Text="Accuracy" FontAttributes="Bold" TextColor="{StaticResource White}" HorizontalTextAlignment="Center"/>
                     <Label Grid.Column="6" Text="Time" FontAttributes="Bold" TextColor="{StaticResource White}" HorizontalTextAlignment="Center"/>
                     <Label Grid.Column="7" Text="Errors" FontAttributes="Bold" TextColor="{StaticResource White}" HorizontalTextAlignment="Center"/>
+                    <Label Grid.Column="8" Text="" FontAttributes="Bold" TextColor="{StaticResource White}" HorizontalTextAlignment="Center"/>
                 </Grid>
 
                 <CollectionView 
@@ -83,7 +84,7 @@
                     <CollectionView.ItemTemplate>
                         <DataTemplate x:DataType="models:ExerciseResult">
                             <Grid 
-                                ColumnDefinitions="*, 0.8*, 0.6*, 0.8*, 0.5*, 0.6*, 0.5*, 0.5*"
+                                ColumnDefinitions="*, 0.8*, 0.6*, 0.8*, 0.6*, 0.7*, 0.5*, 0.6*, 120"
                                 Padding="10,8"
                                 BackgroundColor="Transparent">
 
@@ -92,7 +93,7 @@
                                     Text="{Binding Date}" 
                                     TextColor="{StaticResource Gray100}" 
                                     VerticalTextAlignment="Center"/>
-                                
+
                                 <Label 
                                     Grid.Column="1" 
                                     Text="{Binding Time}" 
@@ -138,6 +139,15 @@
                                     TextColor="{StaticResource Gray100}"
                                     HorizontalTextAlignment="Center"
                                     VerticalTextAlignment="Center"/>
+
+                                <Button 
+                                    Grid.Column="8" 
+                                    Text="Try again"
+                                    Command="{Binding Source={RelativeSource AncestorType={x:Type vm:ProgressViewModel}}, Path=TryAgainCommand}"
+                                    CommandParameter="{Binding .}"
+                                    FontSize="12"
+                                    VerticalOptions="Center"
+                                    HorizontalOptions="Center"/>
                             </Grid>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>

--- a/LearnQuickTyping/LearnQuickTyping.App/Views/ProgressView.xaml
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/ProgressView.xaml
@@ -62,7 +62,7 @@
 
                 <Grid 
                     Grid.Row="0"
-                    ColumnDefinitions="*, 0.8*, 0.6*, 0.8*, 0.6*, 0.7*, 0.5*, 0.6*, 120"
+                    ColumnDefinitions="*, 0.8*, 0.6*, 0.8*, 0.5*, 0.6*, 0.5*, 0.5*"
                     Padding="10,5"
                     BackgroundColor="{StaticResource Gray900}">
                     <Label Grid.Column="0" Text="Date" FontAttributes="Bold" TextColor="{StaticResource White}"/>
@@ -73,7 +73,6 @@
                     <Label Grid.Column="5" Text="Accuracy" FontAttributes="Bold" TextColor="{StaticResource White}" HorizontalTextAlignment="Center"/>
                     <Label Grid.Column="6" Text="Time" FontAttributes="Bold" TextColor="{StaticResource White}" HorizontalTextAlignment="Center"/>
                     <Label Grid.Column="7" Text="Errors" FontAttributes="Bold" TextColor="{StaticResource White}" HorizontalTextAlignment="Center"/>
-                    <Label Grid.Column="8" Text="" FontAttributes="Bold" TextColor="{StaticResource White}" HorizontalTextAlignment="Center"/>
                 </Grid>
 
                 <CollectionView 
@@ -84,7 +83,7 @@
                     <CollectionView.ItemTemplate>
                         <DataTemplate x:DataType="models:ExerciseResult">
                             <Grid 
-                                ColumnDefinitions="*, 0.8*, 0.6*, 0.8*, 0.6*, 0.7*, 0.5*, 0.6*, 120"
+                                ColumnDefinitions="*, 0.8*, 0.6*, 0.8*, 0.5*, 0.6*, 0.5*, 0.5*"
                                 Padding="10,8"
                                 BackgroundColor="Transparent">
 
@@ -93,7 +92,7 @@
                                     Text="{Binding Date}" 
                                     TextColor="{StaticResource Gray100}" 
                                     VerticalTextAlignment="Center"/>
-
+                                
                                 <Label 
                                     Grid.Column="1" 
                                     Text="{Binding Time}" 
@@ -139,15 +138,6 @@
                                     TextColor="{StaticResource Gray100}"
                                     HorizontalTextAlignment="Center"
                                     VerticalTextAlignment="Center"/>
-
-                                <Button 
-                                    Grid.Column="8" 
-                                    Text="Try again"
-                                    Command="{Binding Source={RelativeSource AncestorType={x:Type vm:ProgressViewModel}}, Path=TryAgainCommand}"
-                                    CommandParameter="{Binding .}"
-                                    FontSize="12"
-                                    VerticalOptions="Center"
-                                    HorizontalOptions="Center"/>
                             </Grid>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>


### PR DESCRIPTION
**Summary**
-
This pull request adds the ability for users to retry a previously completed exercise directly from the Progress Overview screen.
A new “Try Again” action has been integrated into the progress results table as an additional column. This allows users to quickly restart an exercise using the same configuration (exercise type and difficulty) without navigating back to the start menu.

**Key changes** 

- Added a dedicated “Try Again” button for each exercise result in the Progress page.
- Connected the button to the `ProgressViewModel`, ensuring correct command binding and navigation back to the exercise view.