### PR TITLE
hotfix: timer start

### DIFF
--- a/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/ViewModels/TextExerciseViewModel.cs
@@ -203,8 +203,13 @@ public partial class TextExerciseViewModel : BaseViewModel
             return;
 
         string safeValue = value ?? string.Empty;
+        
+        if (!_isTiming)
+        {
+            StartTimer();
+        }
 
-         _typeControl.CheckTyping(safeValue);
+        _typeControl.CheckTyping(safeValue);
         _statsService.TrackMistakes(safeValue, TargetText);
 
         RequestLetterUpdate?.Invoke(_typeControl.GetLetterStatuses());


### PR DESCRIPTION
## Summary
This pull request introduces a minor improvement to the typing exercise logic. Now, the timer will automatically start as soon as the user begins typing. The timer still starts after a few seconds even if the user has not started typing yet. This ensures more accurate timing for the exercise.

- Start the timer automatically in `OnTypedTextChanged` when the user starts typing (`TextExerciseViewModel.cs`).