### PR TITLE
hotfix deleting text input

### DIFF
--- a/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
+++ b/LearnQuickTyping/LearnQuickTyping.App/Views/TextExercise.xaml.cs
@@ -180,6 +180,13 @@ public partial class TextExercise : ContentPage
         string currentText = e.NewTextValue ?? string.Empty;
         string oldText = e.OldTextValue ?? string.Empty;
 
+        // Prevent whole text deletions using shortcuts
+        if (currentText.Length < oldText.Length)
+        {
+            // Don't update anything; ignore the deletion attempt
+            return;
+        }
+
         // Update TypedTextLabel based on what was added
         if (currentText.Length == 0)
         {
@@ -191,7 +198,6 @@ public partial class TextExercise : ContentPage
             string addedText = currentText.Substring(oldText.Length);
             TypedTextLabel.Text += addedText;
         }
-        // Note: We don't handle deletion in TypedTextLabel since it's display-only
 
         // Update ViewModel - this triggers the typing check
         _viewModel.TypedText = TypedTextLabel.Text ?? string.Empty;


### PR DESCRIPTION
## Summary

This pull request introduces a safeguard in the `OnTextChanged` event handler to prevent users from deleting the entire exercise text using shortcuts, ensuring the integrity of the typing exercise. The change also clarifies the handling of deletions for the display-only label.

Input handling improvements:

* Added logic in `TextExercise.xaml.cs` to ignore text change events where the new text is shorter than the old text, effectively blocking bulk deletions (e.g., via shortcuts) during typing exercises.